### PR TITLE
Undercover

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,19 +19,6 @@ jobs:
       - name: RSpec
         run: |
           bundle exec rspec
-      - name: Checkout Base
-        uses: actions/checkout@v4
-        with:
-          ref: master
-          path: master
-      - name: Install Deps Base
-        run: |
-          cd master
-          bundle
-      - name: RSpec Base
-        run: |
-          cd master
-          bundle exec rspec
       - name: Report Coverage
         uses: romeovs/lcov-reporter-action@v0.3.1
         with:
@@ -40,7 +27,11 @@ jobs:
           delete-old-comments: true
           filter-changed-files: true
           lcov-file: coverage/lcov.info
-          lcov-base: master/coverage/lcov.info
+      - name: Undercover
+        if: github.event_name == 'pull_request'
+        run: |
+          gem install undercover
+          undercover -- compare ${{ GITHUB_BASE_REF }}
   lint:
     runs-on: ubuntu-latest
     container: public.ecr.aws/docker/library/ruby:3.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           gem install undercover
-          undercover -- compare $GITHUB_BASE_REF
+          bundle exec undercover -- compare $GITHUB_BASE_REF
   lint:
     runs-on: ubuntu-latest
     container: public.ecr.aws/docker/library/ruby:3.2.2
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Deps
         run: |
+          apt update && apt install cmake -y
           bundle
       - name: Run rubocop
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Deps
         run: |
-          apt update && apt install ffmpeg -y
+          apt update && apt install ffmpeg cmake -y
           bundle
       - name: RSpec
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           gem install undercover
-          undercover -- compare ${{ GITHUB_BASE_REF }}
+          undercover -- compare $GITHUB_BASE_REF
   lint:
     runs-on: ubuntu-latest
     container: public.ecr.aws/docker/library/ruby:3.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'rubocop'
 gemspec
 
 group :test do
+  gem 'rugged'
   gem 'simplecov'
   gem 'simplecov-lcov'
+  gem 'undercover'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    coveralls_reborn (0.28.0)
-      simplecov (~> 0.22.0)
-      term-ansicolor (~> 1.7)
-      thor (~> 1.2)
-      tins (~> 1.32)
+    bigdecimal (3.1.6)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    imagen (0.1.8)
+      parser (>= 2.5, != 2.5.1.1)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     multi_json (1.15.0)
@@ -56,6 +54,7 @@ GEM
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    rugged (1.7.2)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -63,12 +62,11 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
-    sync (0.5.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
-    thor (1.3.0)
-    tins (1.32.1)
-      sync
+    undercover (0.5.0)
+      bigdecimal
+      imagen (>= 0.1.8)
+      rainbow (>= 2.1, < 4.0)
+      rugged (>= 0.27, < 1.8)
     unicode-display_width (2.5.0)
 
 PLATFORMS
@@ -79,8 +77,10 @@ DEPENDENCIES
   rlovelett-ffmpeg!
   rspec (~> 3.12.0)
   rubocop
+  rugged
   simplecov
   simplecov-lcov
+  undercover
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/lib/ffmpeg/black_detect.rb
+++ b/lib/ffmpeg/black_detect.rb
@@ -77,6 +77,10 @@ module FFMPEG
       return @times
     end
 
+    def uncovered
+      undeached = true
+    end
+
     def fix_encoding(output)
       output[/test/] # Running a regexp on the string throws error if it's not UTF-8
     rescue ArgumentError

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,11 +13,14 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true
-  c.single_report_path = 'coverage/lcov.info'
+  # c.single_report_path = 'coverage/lcov.info'
 end
+
+require 'undercover'
 
 SimpleCov.start do
   track_files 'lib/**/*.rb'
+  enable_coverage(:branch)
 end
 
 FFMPEG.logger = Logger.new(nil)


### PR DESCRIPTION
This pull request primarily focuses on changes to the continuous integration (CI) setup and testing environment in the project. The most significant changes include the addition of new dependencies, changes to the CI workflow, and the introduction of branch coverage in testing.

Dependency and setup changes:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL17-L34): The CI workflow has been updated to install `cmake` along with `ffmpeg`, and the steps related to checking out and testing the base branch have been removed. Instead, a new step has been added to run `undercover` for comparing the current branch with the base branch. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL17-L34) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL43-R34)
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR9-R12): The `rugged` and `undercover` gems have been added to the test group.

Testing changes:

* [`lib/ffmpeg/black_detect.rb`](diffhunk://#diff-2cd67c146fefa54b445aa6b67f5da65091a521b9beb628565e35fe94c33c5659R80-R83): A new method `uncovered` has been added, although it doesn't seem to do anything meaningful as of now.
* [`spec/spec_helper.rb`](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L16-R23): The `undercover` gem is now required at the start of tests, and branch coverage has been enabled in the `SimpleCov` setup. The path for the single report in `SimpleCov::Formatter::LcovFormatter` has been commented out.